### PR TITLE
Add json_schema option to parameter rules for o1 and o3-mini

### DIFF
--- a/models/openai/models/llm/o1-mini.yaml
+++ b/models/openai/models/llm/o1-mini.yaml
@@ -26,6 +26,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '3.00'
   output: '12.00'

--- a/models/openai/models/llm/o1.yaml
+++ b/models/openai/models/llm/o1.yaml
@@ -42,6 +42,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: "15.00"
   output: "60.00"

--- a/models/openai/models/llm/o3-mini.yaml
+++ b/models/openai/models/llm/o3-mini.yaml
@@ -39,6 +39,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: "1.10"
   output: "4.40"


### PR DESCRIPTION
Add `json_schema` option to parameter rules for `o1`, `o1-mini`, and `o3-mini` models.

* **models/openai/models/llm/o1.yaml**
  - Add `json_schema` to `options` under `parameter_rules`.
  - Add `json_schema` with `use_template: json_schema` to `parameter_rules`.

* **models/openai/models/llm/o1-mini.yaml**
  - Add `json_schema` to `options` under `parameter_rules`.
  - Add `json_schema` with `use_template: json_schema` to `parameter_rules`.

* **models/openai/models/llm/o3-mini.yaml**
  - Add `json_schema` to `options` under `parameter_rules`.
  - Add `json_schema` with `use_template: json_schema` to `parameter_rules`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/knowlet/dify-official-plugins/pull/1?shareId=7de12735-5de4-4006-8445-b58bd0f62eb9).

## Sourcery 总结

新功能：
- 为 `o1`、`o1-mini` 和 `o3-mini` 模型的参数规则添加 `json_schema` 支持

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add `json_schema` support to parameter rules for `o1`, `o1-mini`, and `o3-mini` models

</details>